### PR TITLE
Fix require on objects wich have autoload setted after like propel

### DIFF
--- a/DependencyInjection/Compiler/PointcutMatchingPass.php
+++ b/DependencyInjection/Compiler/PointcutMatchingPass.php
@@ -93,6 +93,10 @@ class PointcutMatchingPass implements CompilerPassInterface
             require_once $file;
         }
 
+        if (!class_exists($definition->getClass())) {
+            return;
+        }
+
         $class = new \ReflectionClass($definition->getClass());
 
         // check if class is matched


### PR DESCRIPTION
When we load the bundle the compiler throw a ReflecionException because classes for services like propel are loaded after you can see a sample checking out the project https://github.com/cedriclombardot/AdmingeneratorIpsum and active the bundle in AppKernel.php
