### PR TITLE
Reusable approach to enhanced proxy generation

### DIFF
--- a/DependencyInjection/Compiler/PointcutMatchingPass.php
+++ b/DependencyInjection/Compiler/PointcutMatchingPass.php
@@ -40,7 +40,6 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 class PointcutMatchingPass implements CompilerPassInterface
 {
     private $pointcuts;
-    private $cacheDir;
     private $container;
 
     public function __construct(array $pointcuts = null)
@@ -51,7 +50,6 @@ class PointcutMatchingPass implements CompilerPassInterface
     public function process(ContainerBuilder $container)
     {
         $this->container = $container;
-        $this->cacheDir = $container->getParameter('jms_aop.cache_dir').'/proxies';
         $pointcuts = $this->getPointcuts();
 
         $interceptors = array();
@@ -150,12 +148,11 @@ class PointcutMatchingPass implements CompilerPassInterface
         if ($file) {
             $generator->setRequiredFile($file);
         }
-        $enhancer = new Enhancer($class, array(), array(
-            $generator
-        ));
-        $enhancer->writeClass($filename = $this->cacheDir.'/'.str_replace('\\', '-', $class->name).'.php');
-        $definition->setFile($filename);
-        $definition->setClass($enhancer->getClassName($class));
+
+        $matcher = $this->container->get('jms_aop.proxy_matcher');
+        $proxy = $matcher->getEnhanced($definition);
+        $proxy->addGenerator($generator);
+
         $definition->addMethodCall('__CGInterception__setLoader', array(
             new Reference('jms_aop.interceptor_loader')
         ));

--- a/DependencyInjection/Compiler/WriteProxiesPass.php
+++ b/DependencyInjection/Compiler/WriteProxiesPass.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @author nfx
+ */
+
+namespace JMS\AopBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+
+class WriteProxiesPass implements CompilerPassInterface
+{
+    function process(ContainerBuilder $container)
+    {
+        $matcher = $container->get('jms_aop.proxy_matcher');
+        $matcher->writeProxyFiles();
+    }
+}

--- a/JMSAopBundle.php
+++ b/JMSAopBundle.php
@@ -20,6 +20,7 @@ namespace JMS\AopBundle;
 
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use JMS\AopBundle\DependencyInjection\Compiler\PointcutMatchingPass;
+use JMS\AopBundle\DependencyInjection\Compiler\WriteProxiesPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -30,5 +31,6 @@ class JMSAopBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         $container->addCompilerPass(new PointcutMatchingPass(), PassConfig::TYPE_AFTER_REMOVING);
+        $container->addCompilerPass(new WriteProxiesPass(), PassConfig::TYPE_AFTER_REMOVING);
     }
 }

--- a/Proxy/ProxyMatcher.php
+++ b/Proxy/ProxyMatcher.php
@@ -29,6 +29,10 @@ class ProxyMatcher
      */
     public function getEnhanced(Definition $definition)
     {
+        if (isset($this->storage[$definition])) {
+            return $this->storage[$definition];
+        }
+
         $promise = new ProxyPromise($this);
         $this->storage[$definition] = $promise;
         return $promise;
@@ -36,7 +40,9 @@ class ProxyMatcher
 
     public function writeProxyFiles()
     {
-        foreach($this->storage as $definition => $promise) {
+        foreach($this->storage as $definition) {
+            $promise = $this->storage[$definition];
+
             $class = new \ReflectionClass($definition->getClass());
             $enhancer = $promise->getEnhancer($class);
 

--- a/Proxy/ProxyMatcher.php
+++ b/Proxy/ProxyMatcher.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * @author nfx
+ */
+
+namespace JMS\AopBundle\Proxy;
+
+use Symfony\Component\DependencyInjection\Definition;
+use CG\Proxy\GeneratorInterface;
+
+class ProxyMatcher
+{
+    protected $cacheDir;
+
+    /**
+     * @var \SplObjectStorage
+     */
+    protected $storage;
+
+    public function __construct($cacheDir)
+    {
+        $this->cacheDir = $cacheDir;
+        $this->storage = new \SplObjectStorage();
+    }
+
+    /**
+     * @param Definition $definition
+     * @return ProxyPromise
+     */
+    public function getEnhanced(Definition $definition)
+    {
+        $promise = new ProxyPromise($this);
+        $this->storage[$definition] = $promise;
+        return $promise;
+    }
+
+    public function writeProxyFiles()
+    {
+        foreach($this->storage as $definition => $promise) {
+            $class = new \ReflectionClass($definition->getClass());
+            $enhancer = $promise->getEnhancer($class);
+
+            $filename = $this->cacheDir.'/'.str_replace('\\', '-', $class->name).'.php';
+            $proxyClassName = $enhancer->getClassName($class);
+
+            $enhancer->writeClass($filename);
+            $definition->setFile($filename);
+            $definition->setClass($proxyClassName);
+        }
+    }
+}

--- a/Proxy/ProxyPromise.php
+++ b/Proxy/ProxyPromise.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @author nfx
+ */
+
+namespace JMS\AopBundle\Proxy;
+use CG\Proxy\GeneratorInterface;
+use CG\Proxy\Enhancer;
+use ReflectionClass;
+
+class ProxyPromise
+{
+    /**
+     * @var GeneratorInterface[]
+     */
+    private $generators = array();
+
+    public function addGenerator(GeneratorInterface $generator)
+    {
+        $this->generators[] = $generator;
+    }
+
+    public function getEnhancer(ReflectionClass $class)
+    {
+        return new Enhancer($class, array(), $this->generators);
+    }
+}

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -6,6 +6,7 @@
 
     <parameters>
         <parameter key="jms_aop.interceptor_loader.class">JMS\AopBundle\Aop\InterceptorLoader</parameter>
+        <parameter key="jms_aop.proxy_matcher.class">JMS\AopBundle\Proxy\ProxyMatcher</parameter>
     </parameters>
 
     <services>
@@ -13,6 +14,10 @@
         
         <service id="jms_aop.interceptor_loader" class="%jms_aop.interceptor_loader.class%">
             <argument type="service" id="service_container" />
+        </service>
+
+        <service id="jms_aop.proxy_matcher" class="%jms_aop.proxy_matcher.class%">
+            <argument>%jms_aop.cache_dir%/proxies</argument>
         </service>
     </services>
 </container>

--- a/Tests/DependencyInjection/Compiler/PointcutMatchingPassTest.php
+++ b/Tests/DependencyInjection/Compiler/PointcutMatchingPassTest.php
@@ -22,7 +22,8 @@ use JMS\AopBundle\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Compiler\ResolveParameterPlaceHoldersPass;
 use JMS\AopBundle\DependencyInjection\JMSAopExtension;
 use JMS\AopBundle\DependencyInjection\Compiler\PointcutMatchingPass;
-use Symfony\Component\HttpKernel\Util\Filesystem;
+use JMS\AopBundle\DependencyInjection\Compiler\WriteProxiesPass;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class PointcutMatchingPassTest extends \PHPUnit_Framework_TestCase
@@ -91,6 +92,9 @@ class PointcutMatchingPassTest extends \PHPUnit_Framework_TestCase
         $pass->process($container);
 
         $pass = new PointcutMatchingPass();
+        $pass->process($container);
+
+        $pass = new WriteProxiesPass();
         $pass->process($container);
     }
 }

--- a/Tests/Proxy/Fixture/AnotherPass.php
+++ b/Tests/Proxy/Fixture/AnotherPass.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @author nfx
+ */
+
+namespace JMS\AopBundle\Tests\Proxy\Fixture;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use JMS\AopBundle\Tests\Proxy\Fixture\SomeGenerator;
+
+class AnotherPass implements CompilerPassInterface
+{
+    function process(ContainerBuilder $container)
+    {
+        $methodName = '__ultimatelyAnotherMethod';
+        $matcher = $container->get('jms_aop.proxy_matcher');
+        $generator = new SomeGenerator($methodName);
+
+        $definition = $container->getDefinition('test');
+
+        $proxy = $matcher->getEnhanced($definition);
+        $proxy->addGenerator($generator);
+        $definition->addMethodCall($methodName);
+    }
+}

--- a/Tests/Proxy/Fixture/FirstPass.php
+++ b/Tests/Proxy/Fixture/FirstPass.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @author nfx
+ */
+
+namespace JMS\AopBundle\Tests\Proxy\Fixture;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use JMS\AopBundle\Tests\Proxy\Fixture\SomeGenerator;
+
+class FirstPass implements CompilerPassInterface
+{
+    function process(ContainerBuilder $container)
+    {
+        $methodName = '__fistPassMethod';
+        $matcher = $container->get('jms_aop.proxy_matcher');
+        $generator = new SomeGenerator($methodName);
+
+        $definition = $container->getDefinition('test');
+
+        $proxy = $matcher->getEnhanced($definition);
+        $proxy->addGenerator($generator);
+        $definition->addMethodCall($methodName);
+    }
+}

--- a/Tests/Proxy/Fixture/SomeGenerator.php
+++ b/Tests/Proxy/Fixture/SomeGenerator.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * @author nfx
+ */
+
+namespace JMS\AopBundle\Tests\Proxy\Fixture;
+
+use CG\Proxy\GeneratorInterface;
+use CG\Generator\PhpClass;
+use CG\Generator\PhpMethod;
+
+class SomeGenerator implements GeneratorInterface
+{
+    public $methodName;
+
+    public function __construct($methodName)
+    {
+        $this->methodName = $methodName;
+    }
+
+    /**
+     * Generates the necessary changes in the class.
+     *
+     * @param \ReflectionClass $originalClass
+     * @param PhpClass $generatedClass The generated class
+     * @return void
+     */
+    function generate(\ReflectionClass $originalClass, PhpClass $generatedClass)
+    {
+        $method = PhpMethod::create($this->methodName)
+            ->setBody("\$this->things[] = '{$this->methodName}';");
+        $generatedClass->setMethod($method);
+    }
+}

--- a/Tests/Proxy/Fixture/TestService.php
+++ b/Tests/Proxy/Fixture/TestService.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * @author nfx
+ */
+
+namespace JMS\AopBundle\Tests\Proxy\Fixture;
+
+class TestService
+{
+    protected $things = array();
+
+    public function getThings()
+    {
+        return $this->things;
+    }
+}

--- a/Tests/Proxy/ProxyMatcherTest.php
+++ b/Tests/Proxy/ProxyMatcherTest.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * @author nfx
+ */
+
+namespace JMS\AopBundle\Tests\Proxy;
+
+use JMS\AopBundle\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\Compiler\ResolveParameterPlaceHoldersPass;
+use JMS\AopBundle\DependencyInjection\JMSAopExtension;
+use JMS\AopBundle\DependencyInjection\Compiler\WriteProxiesPass;
+use JMS\AopBundle\Tests\Proxy\Fixture\FirstPass;
+use JMS\AopBundle\Tests\Proxy\Fixture\AnotherPass;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class ProxyMatcherTest extends \PHPUnit_Framework_TestCase
+{
+    private $cacheDir;
+    private $fs;
+
+    public function testProcess()
+    {
+        $container = $this->getContainer();
+        $container->register('test', 'JMS\AopBundle\Tests\Proxy\Fixture\TestService');
+
+        $this->process($container);
+
+        $service = $container->get('test');
+        $this->assertInstanceOf('JMS\AopBundle\Tests\Proxy\Fixture\TestService', $service);
+
+        $this->assertEquals(array('__fistPassMethod', '__ultimatelyAnotherMethod'), $service->getThings());
+    }
+
+    protected function setUp()
+    {
+        $this->cacheDir = sys_get_temp_dir() . '/jms_aop_test';
+        $this->fs = new Filesystem();
+
+        if (is_dir($this->cacheDir)) {
+            $this->fs->remove($this->cacheDir);
+        }
+
+        if (false === @mkdir($this->cacheDir, 0777, true)) {
+            throw new RuntimeException(sprintf('Could not create cache dir "%s".', $this->cacheDir));
+        }
+    }
+
+    protected function tearDown()
+    {
+        $this->fs->remove($this->cacheDir);
+    }
+
+    private function getContainer()
+    {
+        $container = new ContainerBuilder();
+
+        $extension = new JMSAopExtension();
+        $extension->load(array(array('cache_dir' => $this->cacheDir)), $container);
+
+        return $container;
+    }
+
+    private function process(ContainerBuilder $container)
+    {
+        $pass = new ResolveParameterPlaceHoldersPass();
+        $pass->process($container);
+
+        $pass = new FirstPass();
+        $pass->process($container);
+
+        $pass = new AnotherPass();
+        $pass->process($container);
+
+        $pass = new WriteProxiesPass();
+        $pass->process($container);
+    }
+}

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -1,0 +1,15 @@
+<?php
+
+// this file searches for the autoload file of your project, and includes it
+$dir = __DIR__;
+$lastDir = null;
+while (($dir = dirname($dir)) && $dir !== $lastDir) {
+	$lastDir = $dir;
+
+	if (file_exists($file = $dir.'/app/autoload.php')) {
+		require_once $file;
+		return;
+	}
+}
+
+throw new RuntimeException('Could not locate the project\'s bootstrap.php.cache. If your bundle is not inside a project, you need to replace this bootstrap file.');

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,7 +9,7 @@
          processIsolation="false"
          stopOnFailure="false"
          syntaxCheck="false"
-         bootstrap="./../../../../app/bootstrap.php.cache"
+         bootstrap="./Tests/bootstrap.php"
 >
          
     <testsuites>


### PR DESCRIPTION
Goal:
- some bundles want to define their own code enhancement rules
- if two bundles enhance the same class - there would be no risk of conflicts
- couple of bundles won't overwrite changes of each other, as they'll define their own generators

How:
- added proxy enhancer repository
- supported code with tests
- fixed single failing test with outdated class name
- now tests run normally on 2.1 composer based install

Regards,
Serge
