### PR TITLE
Alter the PointcutInterface::matchesMethod to include the ClassReflectio...

### DIFF
--- a/Aop/PointcutInterface.php
+++ b/Aop/PointcutInterface.php
@@ -37,6 +37,7 @@ interface PointcutInterface
      * annotations.
      *
      * @param \ReflectionClass $class
+     *
      * @return boolean
      */
     function matchesClass(\ReflectionClass $class);
@@ -47,8 +48,10 @@ interface PointcutInterface
      * This method is not limited in the way the matchesClass method is. It may
      * use information in the associated class to make its decision.
      *
+     * @param \ReflectionClass $class
      * @param \ReflectionMethod $method
+     *
      * @return boolean
      */
-    function matchesMethod(\ReflectionMethod $method);
+    function matchesMethod(\ReflectionClass $class, \ReflectionMethod $method);
 }

--- a/Aop/RegexPointcut.php
+++ b/Aop/RegexPointcut.php
@@ -29,17 +29,26 @@ class RegexPointcut implements PointcutInterface
 {
     private $pattern;
 
+    /**
+     * @param string $pattern
+     */
     public function __construct($pattern)
     {
         $this->pattern = $pattern;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function matchesClass(\ReflectionClass $class)
     {
         return true;
     }
 
-    public function matchesMethod(\ReflectionMethod $method)
+    /**
+     * {@inheritdoc}
+     */
+    public function matchesMethod(\ReflectionClass $class, \ReflectionMethod $method)
     {
         return 0 < preg_match('#'.$this->pattern.'#', sprintf('%s::%s', $method->class, $method->name));
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+CHANGELOG
+=========
+
+* 2012-08-20
+
+    *  [BC BREAK] alter the ``PointcutInterface::matchedMethod`` signature to pass the ReflectionClass instance

--- a/DependencyInjection/Compiler/PointcutMatchingPass.php
+++ b/DependencyInjection/Compiler/PointcutMatchingPass.php
@@ -124,8 +124,9 @@ class PointcutMatchingPass implements CompilerPassInterface
             }
 
             $advices = array();
+
             foreach ($matchingPointcuts as $interceptor => $pointcut) {
-                if ($pointcut->matchesMethod($method)) {
+                if ($pointcut->matchesMethod($class, $method)) {
                     $advices[] = $interceptor;
                 }
             }

--- a/Tests/Aop/RegexPointcutTest.php
+++ b/Tests/Aop/RegexPointcutTest.php
@@ -32,11 +32,12 @@ class RegexPointcutTest extends \PHPUnit_Framework_TestCase
     {
         $pointcut = new RegexPointcut('foo$');
 
+        $class = new \ReflectionClass('JMS\AopBundle\Tests\Aop\RegexPointcutTestClass');
         $method = new \ReflectionMethod('JMS\AopBundle\Tests\Aop\RegexPointcutTestClass', 'foo');
-        $this->assertTrue($pointcut->matchesMethod($method));
+        $this->assertTrue($pointcut->matchesMethod($class, $method));
 
         $method = new \ReflectionMethod('JMS\AopBundle\Tests\Aop\RegexPointcutTestClass', 'bar');
-        $this->assertFalse($pointcut->matchesMethod($method));
+        $this->assertFalse($pointcut->matchesMethod($class, $method));
     }
 }
 

--- a/Tests/DependencyInjection/Compiler/Fixture/LoggingPointcut.php
+++ b/Tests/DependencyInjection/Compiler/Fixture/LoggingPointcut.php
@@ -22,12 +22,13 @@ use JMS\AopBundle\Aop\PointcutInterface;
 
 class LoggingPointcut implements PointcutInterface
 {
+
     public function matchesClass(\ReflectionClass $class)
     {
         return true;
     }
 
-    public function matchesMethod(\ReflectionMethod $method)
+    public function matchesMethod(\ReflectionClass $class, \ReflectionMethod $method)
     {
         return false !== strpos($method->name, 'delete');
     }

--- a/Tests/DependencyInjection/Compiler/PointcutMatchingPassTest.php
+++ b/Tests/DependencyInjection/Compiler/PointcutMatchingPassTest.php
@@ -22,7 +22,7 @@ use JMS\AopBundle\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Compiler\ResolveParameterPlaceHoldersPass;
 use JMS\AopBundle\DependencyInjection\JMSAopExtension;
 use JMS\AopBundle\DependencyInjection\Compiler\PointcutMatchingPass;
-use Symfony\Component\HttpKernel\Util\Filesystem;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class PointcutMatchingPassTest extends \PHPUnit_Framework_TestCase


### PR DESCRIPTION
...n instance

The current PointcutInterface methods signature is only valid if one Pointcut
handle one class. However if a Pointcut is implemented to handle more than
one class then the model is broken. The MethodReflection contains the class
where the method is defined and not the class referenced in a sub type class.

So this patch solves the issue by providing the ReflectionClass targetted by
the configuration.
