### PR TITLE
Make proxy classes env dependent

### DIFF
--- a/DependencyInjection/Compiler/PointcutMatchingPass.php
+++ b/DependencyInjection/Compiler/PointcutMatchingPass.php
@@ -19,6 +19,7 @@
 namespace JMS\AopBundle\DependencyInjection\Compiler;
 
 use CG\Core\ClassUtils;
+use CG\Core\DefaultNamingStrategy;
 use JMS\AopBundle\Exception\RuntimeException;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\Reference;
@@ -167,6 +168,7 @@ class PointcutMatchingPass implements CompilerPassInterface
         $enhancer = new Enhancer($class, array(), array(
             $generator
         ));
+        $enhancer->setNamingStrategy(new DefaultNamingStrategy('EnhancedProxy'.substr(md5($this->container->getParameter('jms_aop.cache_dir')), 0, 8)));
         $enhancer->writeClass($filename = $this->cacheDir.'/'.str_replace('\\', '-', $class->name).'.php');
         $definition->setFile($filename);
         $definition->setClass($enhancer->getClassName($class));


### PR DESCRIPTION
Without this, if we use two differents envs in tests we get conflicting classes, for some reason the bundle requires the proxy twice (once in env A, once in env B) and we get a fatal because the class already exists.

Note that a similar thing might need to be applied to https://github.com/schmittjoh/JMSDiExtraBundle/blob/master/HttpKernel/ControllerResolver.php#L187 - but I can't say for sure since I'm not sure when that code is executed.
