### PR TITLE
Adaption for complying with SPDX identifiers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Adds AOP capabilities to Symfony2",
     "keywords": ["annotations","aop"],
     "type": "symfony-bundle",
-    "license": "Apache",
+    "license": "Apache-2.0",
     "authors": [
         {
             "name": "Johannes M. Schmitt",


### PR DESCRIPTION
I currently oversee the licenses used in our projects

It would make sense to update the file as suggested in order to comply with the license identifiers as listed by SPDX
http://spdx.org/licenses/

Reasoning:
"Apache" could imply any version of the license, whereby only version 2 is compatible with the GPL v3. 
For details e.g. see http://www.gnu.org/licenses/license-list.html#GPLIncompatibleLicenses