### PR TITLE
Fix deprecated calls

### DIFF
--- a/DependencyInjection/Compiler/PointcutMatchingPass.php
+++ b/DependencyInjection/Compiler/PointcutMatchingPass.php
@@ -99,7 +99,12 @@ class PointcutMatchingPass implements CompilerPassInterface
             return;
         }
 
-        if ($definition->getFactoryService() || $definition->getFactoryClass()) {
+        // Symfony 2.6 getFactory method
+        // TODO: Use only getFactory when bumping require to Symfony >= 2.6
+        if (method_exists($definition, 'getFactory') && $definition->getFactory()) {
+            return;
+        }
+        if (!method_exists($definition, 'getFactory') && ($definition->getFactoryService() || $definition->getFactoryClass())) {
             return;
         }
 


### PR DESCRIPTION
This PR is intended to fix some deprecated usage.

I manage it to keep Symfony 2.3+ BC.

Actually I still have those two notices:

```
The Symfony\Component\Security\Core\SecurityContext class is deprecated since version 2.6 and will be removed in 3.0.
[...]
PHP   8. JMS\AopBundle\DependencyInjection\Compiler\PointcutMatchingPass->process() /project/vendor/symfony/symfony/src/Symfony/Component/DependencyInjection/Compiler/Compiler.php:117
PHP   9. JMS\AopBundle\DependencyInjection\Compiler\PointcutMatchingPass->processDefinition() /project/vendor/jms/aop-bundle/JMS/AopBundle/DependencyInjection/Compiler/PointcutMatchingPass.php:64
PHP  10. class_exists() /project/vendor/jms/aop-bundle/JMS/AopBundle/DependencyInjection/Compiler/PointcutMatchingPass.php:114
[...]
```

```
The Symfony\Component\Security\Core\SecurityContextInterface interface is deprecated since version 2.6 and will be removed in 3.0.
[...]
PHP   8. JMS\AopBundle\DependencyInjection\Compiler\PointcutMatchingPass->process() /project/vendor/symfony/symfony/src/Symfony/Component/DependencyInjection/Compiler/Compiler.php:117
PHP   9. JMS\AopBundle\DependencyInjection\Compiler\PointcutMatchingPass->processDefinition() /project/vendor/jms/aop-bundle/JMS/AopBundle/DependencyInjection/Compiler/PointcutMatchingPass.php:64
PHP  10. class_exists() /project/vendor/jms/aop-bundle/JMS/AopBundle/DependencyInjection/Compiler/PointcutMatchingPass.php:114
PHP  11. spl_autoload_call() /project/vendor/jms/aop-bundle/JMS/AopBundle/DependencyInjection/Compiler/PointcutMatchingPass.php:114
PHP  12. Symfony\Component\Debug\DebugClassLoader->loadClass() /project/vendor/jms/aop-bundle/JMS/AopBundle/DependencyInjection/Compiler/PointcutMatchingPass.php:0
[...]
```

But I can't find how to solve it, can you gave my some indications?

Thanks.