### PR TITLE
Disabled deprecation notice

### DIFF
--- a/DependencyInjection/Compiler/PointcutMatchingPass.php
+++ b/DependencyInjection/Compiler/PointcutMatchingPass.php
@@ -99,7 +99,7 @@ class PointcutMatchingPass implements CompilerPassInterface
             return;
         }
 
-        if ($definition->getFactoryService() || $definition->getFactoryClass()) {
+        if ($definition->getFactoryService(false) || $definition->getFactoryClass(false)) {
             return;
         }
 


### PR DESCRIPTION
As a quick "fix" I have disabled the deprecation warning. This is not a proper fix, but it's better than seeing 2000 (literally) warnings because of this problem... this will only work in symfony 2.x, we have until 3.0 to do a real fix.