### PR TITLE
Removing calls to deprecated functions getFactoryClass & getFactoryMethod

### DIFF
--- a/DependencyInjection/Compiler/PointcutMatchingPass.php
+++ b/DependencyInjection/Compiler/PointcutMatchingPass.php
@@ -99,7 +99,7 @@ class PointcutMatchingPass implements CompilerPassInterface
             return;
         }
 
-        if ($definition->getFactoryService() || $definition->getFactoryClass()) {
+        if ($definition->getFactory()) {
             return;
         }
 


### PR DESCRIPTION
These method calls spewed walls of text notices when used with symfony 2.7.

There's another one I didn't fix 8 lines below `if (!class_exists($definition->getClass()))` includes the deprecated `SecurityContext` class which has a `trigger_error` directly in the file (so the error is seen when including the file even if the class is not used).
