### PR TITLE
Add symfony 3.0 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor
+composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+language: php
+
+php:
+    - 5.3
+    - 5.4
+    - 5.5
+    - 5.6
+
+sudo: false
+
+cache:
+    directories:
+        - $HOME/.composer/cache/files
+
+matrix:
+    fast_finish: true
+    include:
+        - php: 5.3
+          env: COMPOSER_FLAGS="--prefer-lowest" SYMFONY_DEPRECATIONS_HELPER=weak
+        - php: 5.6
+          env: SYMFONY_VERSION='2.7.*'
+        - php: 5.6
+          env: SYMFONY_VERSION='2.8.*'
+
+before_install:
+    - composer self-update
+    - if [ "$SYMFONY_VERSION" != "" ]; then composer require --dev --no-update symfony/symfony=$SYMFONY_VERSION; fi
+
+install: composer update $COMPOSER_FLAGS
+
+script: phpunit

--- a/DependencyInjection/Compiler/PointcutMatchingPass.php
+++ b/DependencyInjection/Compiler/PointcutMatchingPass.php
@@ -100,7 +100,12 @@ class PointcutMatchingPass implements CompilerPassInterface
             return;
         }
 
-        if ($definition->getFactoryService() || $definition->getFactoryClass()) {
+        // Symfony 2.6 getFactory method
+        // TODO: Use only getFactory when bumping require to Symfony >= 2.6
+        if (method_exists($definition, 'getFactory') && $definition->getFactory()) {
+            return;
+        }
+        if (!method_exists($definition, 'getFactory') && ($definition->getFactoryService() || $definition->getFactoryClass())) {
             return;
         }
 

--- a/composer.json
+++ b/composer.json
@@ -11,16 +11,19 @@
         }
     ],
     "require": {
-        "symfony/framework-bundle": "2.*",
+        "php": ">=5.3.9",
+        "symfony/framework-bundle": "^2.3|^3.0",
         "jms/cg": "^1.1"
     },
+    "require-dev": {
+        "symfony/phpunit-bridge": "^2.7"
+    },
     "autoload": {
-        "psr-0": { "JMS\\AopBundle": "" }
+        "psr-4": { "JMS\\AopBundle\\": "" }
     },
     "extra": {
         "branch-alias": {
             "dev-master": "1.1.x-dev"
         }
-    },
-    "target-dir": "JMS/AopBundle"
+    }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,7 +9,7 @@
          processIsolation="false"
          stopOnFailure="false"
          syntaxCheck="false"
-         bootstrap="./../../../../../app/bootstrap.php.cache"
+         bootstrap="vendor/autoload.php"
 >
 
     <testsuites>


### PR DESCRIPTION
This PR adds symfony 3.0 support to the bundle.
It includes #26.

Please review it @schmittjoh as many of your bundles can't be upgraded because of this one.