### PR TITLE
fix: PHP Deprecated: Not quoting the scalar "%kernel.cache_dir%/jms_a…

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -47,7 +47,7 @@ Configuration
 ::
 
     jms_aop:
-        cache_dir: %kernel.cache_dir%/jms_aop
+        cache_dir: '%kernel.cache_dir%/jms_aop'
 
 
 Usage


### PR DESCRIPTION
…op" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0 on line 72.